### PR TITLE
feat: add search.google.com to the list of allowed ggl.link

### DIFF
--- a/packages/utils/src/constants/dub-domains.ts
+++ b/packages/utils/src/constants/dub-domains.ts
@@ -100,6 +100,7 @@ export const DUB_DOMAINS = [
             "calendar.google.com",
             "maps.google.com",
             "photos.google.com",
+            "search.google.com",
             "googleblog.com",
             "developers.googleblog.com",
             "chromewebstore.google.com",


### PR DESCRIPTION
Resolve problem preventing the use of search.google.com links with ggl.link.

<img width="437" src="https://github.com/user-attachments/assets/44f6bc9c-08f3-41f1-9460-0a4542ea009d">

